### PR TITLE
Add VCS annotation gradient colors for Night, Storm, and Contrast variants

### DIFF
--- a/src/main/resources/themes/TokyoDark.xml
+++ b/src/main/resources/themes/TokyoDark.xml
@@ -59,11 +59,11 @@
         <option name="SEPARATOR_BELOW_COLOR" value="2c2e40"/>
         <option name="SOFT_WRAP_SIGN_COLOR" value="2c2e40"/>
         <option name="TEARLINE_COLOR" value="2c2e40"/>
-        <option name="VCS_ANNOTATIONS_COLOR_1" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_2" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_3" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_4" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_5" value="232433"/>
+        <option name="VCS_ANNOTATIONS_COLOR_1" value="3d59a1"/>
+        <option name="VCS_ANNOTATIONS_COLOR_2" value="343b63"/>
+        <option name="VCS_ANNOTATIONS_COLOR_3" value="2f3352"/>
+        <option name="VCS_ANNOTATIONS_COLOR_4" value="2a2f48"/>
+        <option name="VCS_ANNOTATIONS_COLOR_5" value="1f2335"/>
         <option name="VISUAL_INDENT_GUIDE" value="2c2e40"/>
         <option name="WHITESPACES" value="2c2e40"/>
         <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="e0af68"/>

--- a/src/main/resources/themes/TokyoDarkContrast.xml
+++ b/src/main/resources/themes/TokyoDarkContrast.xml
@@ -59,11 +59,11 @@
         <option name="SEPARATOR_BELOW_COLOR" value="2c2e40"/>
         <option name="SOFT_WRAP_SIGN_COLOR" value="2c2e40"/>
         <option name="TEARLINE_COLOR" value="2c2e40"/>
-        <option name="VCS_ANNOTATIONS_COLOR_1" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_2" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_3" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_4" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_5" value="232433"/>
+        <option name="VCS_ANNOTATIONS_COLOR_1" value="475d9a"/>
+        <option name="VCS_ANNOTATIONS_COLOR_2" value="36426b"/>
+        <option name="VCS_ANNOTATIONS_COLOR_3" value="2b3350"/>
+        <option name="VCS_ANNOTATIONS_COLOR_4" value="1f2230"/>
+        <option name="VCS_ANNOTATIONS_COLOR_5" value="16161e"/>
         <option name="VISUAL_INDENT_GUIDE" value="2c2e40"/>
         <option name="WHITESPACES" value="2c2e40"/>
         <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="e0af68"/>

--- a/src/main/resources/themes/TokyoDarkStorm.xml
+++ b/src/main/resources/themes/TokyoDarkStorm.xml
@@ -59,11 +59,11 @@
         <option name="SEPARATOR_BELOW_COLOR" value="2c2e40"/>
         <option name="SOFT_WRAP_SIGN_COLOR" value="2c2e40"/>
         <option name="TEARLINE_COLOR" value="2c2e40"/>
-        <option name="VCS_ANNOTATIONS_COLOR_1" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_2" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_3" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_4" value="232433"/>
-        <option name="VCS_ANNOTATIONS_COLOR_5" value="232433"/>
+        <option name="VCS_ANNOTATIONS_COLOR_1" value="4b68a5"/>
+        <option name="VCS_ANNOTATIONS_COLOR_2" value="3c4f72"/>
+        <option name="VCS_ANNOTATIONS_COLOR_3" value="334061"/>
+        <option name="VCS_ANNOTATIONS_COLOR_4" value="2a3150"/>
+        <option name="VCS_ANNOTATIONS_COLOR_5" value="24283b"/>
         <option name="VISUAL_INDENT_GUIDE" value="2c2e40"/>
         <option name="WHITESPACES" value="2c2e40"/>
         <option name="WHITESPACES_MODIFIED_LINES_COLOR" value="e0af68"/>


### PR DESCRIPTION
# Add VCS annotation gradient colors for Night, Storm, and Contrast variants
## Summary
- This update introduces proper gradient colors for VCS annotations (`Annotate with Git Blame`) across all TokyoNight variants (Night, Storm, Contrast).
- Previously, all variants used a single dark tone for annotations, making it hard to distinguish recent and older commits.

<img width="237" height="404" alt="image" src="https://github.com/user-attachments/assets/17d7335a-2c0e-400c-a715-ee25b9454453" />

## Color Palette
### TokyoDark
<img width="1553" height="623" alt="image" src="https://github.com/user-attachments/assets/2e133f8a-4279-41b7-96b2-1f06b3caeead" />

###  TokyoDarkStorm
<img width="1529" height="606" alt="image" src="https://github.com/user-attachments/assets/99578760-1aa1-49e8-8245-b0b0b9d36b03" />

### TokyoDarkContrast
<img width="1527" height="578" alt="image" src="https://github.com/user-attachments/assets/2d2d1964-3305-4ea8-af15-cccc07260e9c" />

## Real Implementation
### TokyoDark
<img width="1774" height="1593" alt="image" src="https://github.com/user-attachments/assets/a456f2dd-80b8-43d7-a8d2-0154c2258fd2" />

### TokyoDarkStorm
<img width="1771" height="1588" alt="image" src="https://github.com/user-attachments/assets/a0b94657-e779-4ff4-a333-2799e081d8c4" />

### TokyoDarkContrast
<img width="1810" height="1593" alt="image" src="https://github.com/user-attachments/assets/c215bc26-c2ab-4cce-b65b-7e82994f5f51" />